### PR TITLE
Added authorization framework

### DIFF
--- a/envExample.txt
+++ b/envExample.txt
@@ -13,3 +13,5 @@ SERVER_PUBLIC_URL=http://localhost:8080
 
 EMAIL_USER="email to send from"
 EMAIL_PASS="email password"
+
+SESSION_SECRET="random, secure string. preferably >32 char long"

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 
 const express = require("express");
 var app = express();
+var sessions = require("client-sessions");
 
 
 // dependencies
@@ -15,44 +16,122 @@ const mailService = require(__dirname + "/modules/emailService.js")
 app.use(express.static("public"));
 
 
-// routes
+app.use(sessions({
+	cookieName: 'auth',
+	secret: process.env.SESSION_SECRET,
+	duration: 1 * 1 * 60 * 1000, 		// HH * MM * SS * MS | fill with ones to the left
+	activeDuration: 1 * 1 * 60 * 1000 
+}));
+
+
+
+
+// ROUTES
+// 		->	GET 	Place all GET routes here
+
 app.get("/send_verification_email_test/:email", (req, res) => {
-    let email = req.params.email;
+	let email = req.params.email;
 
-    mailService.sendVerificationEmail(email, "id")
-        .then((e) => {
-            res.send("Email sent to " + e);
-        })
-        .catch((e) => {
-            res.send("Couldn't send email. Check the URL and try again.")
+	mailService.sendVerificationEmail(email, "id")
+		.then((e) => {
+			res.send("Email sent to " + e);
+		})
+		.catch((e) => {
+			res.send("Couldn't send email. Check the URL and try again.")
 
-            if(e.toString().indexOf("Greeting") >= 0){
-                console.log(e + "\n\n\n ***CHECK YOUR FIREWALL FOR PORT 587***");
-            }
+			if (e.toString().indexOf("Greeting") >= 0) {
+				console.log(e + "\n\n\n ***CHECK YOUR FIREWALL FOR PORT 587***");
+			}
 
-            
-        })
+
+		})
 })
 
 
-app.get("/verify_email/:email/:token", (req, res)=>{
-    let token = req.params.token;
-    let email = req.params.email;
+app.get("/verify_email/:email/:token", (req, res) => {
+	let token = req.params.token;
+	let email = req.params.email;
 
-    mailService.verifyEmailToken(token, email)
-        .then((email)=>{
-            res.send(`The email ${email} has been verified.`)
-        })
-        .catch((error)=>{
-            res.json(error)
-        })
+	mailService.verifyEmailToken(token, email)
+		.then((email) => {
+			res.send(`The email ${email} has been verified.`)
+		})
+		.catch((error) => {
+			res.json(error)
+		})
 
 
+})
+
+
+// this will move to the post route when form data is needed
+app.get("/login", (req, res) => {
+
+	// We're going to simulate a user that would be returned from the database
+	const user = {
+		id: 1,
+		name: "John Smith",
+		company: "Paintings4You",
+		email: "email@email.com",
+		password: "asecretnonplaintextpassword"
+	}
+
+
+	// this might look a bit weird, but it's using ES6 destructuring to strip the password field just to make SURE we're not passing it back and forth
+	// it basically pulls out the password field from the user object if there is one, and collects all the remaining properties into the strippedUser object
+	const{
+		password,
+		...strippedUser
+	} = user;
+	
+
+	req.auth.isLoggedIn = true;
+	req.auth.userDetails = strippedUser;
+	res.send("logged in");
+})
+
+
+
+app.get('/about_me', (req, res) => {
+	if(req.auth.isLoggedIn){
+		res.json(req.auth)
+	} else{
+		res.sendStatus(403)
+	}
+	
+});
+
+
+
+app.get('/logout', (req, res)=>{
+	req.auth.isLoggedIn = false;
+	req.auth.userDetails = {};
+	res.send("logged out")
+})
+
+
+
+
+// ROUTES
+// 		->	POST 	Place all POST routes here
+
+
+
+
+// Express MiddleWares
+
+
+
+
+
+// fallback for unknown routes
+app.get("*", (req, res) => {
+	res.send("404 NOT FOUND");
 })
 
 
 
 // start listening 
 app.listen(process.env.SERVER_PORT || 8080, process.env.SERVER_HOSTNAME, () => {
-    console.log("server listening on port " + process.env.SERVER_PORT || 8080);
+	console.log("server listening on port " + process.env.SERVER_PORT || 8080);
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,14 @@
         "readdirp": "~3.3.0"
       }
     },
+    "client-sessions": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.8.0.tgz",
+      "integrity": "sha1-p9jFVYrV1W8qGZ81M+tlS134k/0=",
+      "requires": {
+        "cookies": "^0.7.0"
+      }
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -109,6 +117,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookies": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.3.tgz",
+      "integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
+      "requires": {
+        "depd": "~1.1.2",
+        "keygrip": "~1.0.3"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -291,6 +308,11 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "keygrip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
+      "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "bootstrap": "^4.4.1",
+    "client-sessions": "^0.8.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "nodemailer": "^6.4.2",


### PR DESCRIPTION
Fixes #27 

Uses client-sessions to protect routes unless a user "logs in". Since DB and forms aren't created yet, you login via the `/login` route, which allows access to the `/about_me` route. If you are not logged in, the `/about_me` route returns a `403` status. You can log out via `/logout`. 


Authorization is passed via a session cookie called `auth` which contains:

`bool isLoggedIn` - a boolean verifying that the user is logged in

`object userdetails` - an object containing the user object, stripped of unnecessary information (password)


The `auth` cookie can be accessed via the `req` object passed on the routes (`req.auth`)

The cookie also expires, right now it is set to a fairly short period of time (1min) but is extended by 1min when the user is active.


Also, indenting was altered, we should set up prettier so we don't keep changing it.


.env is updated with an added SESSION_SECRET which should be a long, unguessable string for securely encrypting the cookie.