### PR TITLE
Cleanup

### DIFF
--- a/views/layouts/dashboard.hbs
+++ b/views/layouts/dashboard.hbs
@@ -26,7 +26,7 @@
 						Change<br/>
 						Picture
 					</a>
-					<img src="siteData/{{userDetails._id}}/img/avatar/avatar" onerror="this.src='../img/default_profile.jpg'; this.onerror= null" alt="">
+					<img src="/siteData/{{userDetails._id}}/img/avatar/avatar" onerror="this.src='/img/default_profile.jpg'; this.onerror= null" alt="logo">
 				
 				
 				</div>

--- a/views/partials/avatarModal.hbs
+++ b/views/partials/avatarModal.hbs
@@ -1,34 +1,34 @@
 <!--Modal: Login with Avatar Form-->
 <div class="modal fade" id="avatarModal">
-  <div class="modal-dialog cascading-modal modal-avatar modal-sm">
-    <!--Content-->
-    
-    <div class="modal-content">
-        <div class="modal-title text-center">
-            <h3 class="mb-0 mt-1"><b>Change Profile Picture</b></h3>
-            </div>
-            <hr>
-      <!--Header-->
-      <div class="modal-header">  
-           <img src="siteData/{{userDetails._id}}/img/avatar/avatar" onerror="this.src='../img/default_profile.jpg'; this.onerror= null" alt="avatar" style="width:200px;height:200px" class="rounded-circle mx-auto">
+	<div class="modal-dialog cascading-modal modal-avatar modal-sm">
+		<!--Content-->
 
-      </div>
-      <!--Body-->
-      <div class="modal-body text-center mb-1">
-          <form action="/uploadAvatar" enctype="multipart/form-data" method="POST">
-         
-          <input type="file"  name="avatarImg" id="displayPic" class="form-control">
-        <div class="text-center mt-4">
-          <button type="submit" class="btn btn-primary">Change Avatar<i class="fas fa-sign-in"></i></button>
-        </div>
-        
-        </form>
+		<div class="modal-content">
+			<div class="modal-title text-center">
+				<h3 class="mb-0 mt-1"><b>Change Profile Picture</b></h3>
+			</div>
+			<hr>
+			<!--Header-->
+			<div class="modal-header">
+				<img src="/siteData/{{userDetails._id}}/img/avatar/avatar" onerror="this.src='/img/default_profile.jpg'; this.onerror= null" alt="avatar" style="width:200px;height:200px" class="rounded-circle mx-auto">
+
+			</div>
+			<!--Body-->
+			<div class="modal-body text-center mb-1">
+				<form action="/uploadAvatar" enctype="multipart/form-data" method="POST">
+
+					<input type="file" name="avatarImg" id="displayPic" class="form-control">
+					<div class="text-center mt-4">
+						<button type="submit" class="btn btn-primary">Change Avatar<i class="fas fa-sign-in"></i></button>
+					</div>
+
+				</form>
 
 
 
-      </div>
+			</div>
 
-    </div>
-    <!--/.Content-->
-  </div>
+		</div>
+		<!--/.Content-->
+	</div>
 </div>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -12,7 +12,6 @@
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.3.0/ekko-lightbox.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.3.0/ekko-lightbox.js.map"></script>
 
 <!-- sheets -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />


### PR DESCRIPTION
@tselouie when referencing web paths on the front end (on img src tags for example) we cant use paths like `./path/to/img` or `../path/to/img`. We either need to use an absolute path (starting with just `/` to reference the root server route) or we can go _down_ the path structure by not having the leading slash. We can't navigate up the folder structure relatively though, only via an absolute path.

**Example:** 
If we're on the webpage `http://localhost/path` we can reference an image found under `$project_root/public/path/to/img` by using either:

`src="to/img"` 
or
`src="/path/to/img"`


but we **can't** do:

`src="./path/to/img"`

or move up a level using `../` cause the browser doesn't really know the folder structure of the server, it just know what the root domain is and the route/page we're on right now.
